### PR TITLE
Add OpenCV for building opencv_cvbridge_tutorial

### DIFF
--- a/opencv_cvbridge_tutorial/CMakeLists.txt
+++ b/opencv_cvbridge_tutorial/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
-
+find_package(OpenCV REQUIRED)
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
@@ -114,6 +114,7 @@ include_directories(
 ## Specify libraries to link a library or executable target against
  target_link_libraries(opencv_cvbridge_tutorial_node
    ${catkin_LIBRARIES}
+   ${OpenCV_LIBRARIES}
  )
 
 #############


### PR DESCRIPTION
opencv_cvbridge_tutorial built failed. It can not find the OpenCV for dependency.

> CMakeFiles/opencv_cvbridge_tutorial_node.dir/src/image_converter.cpp.o: In function `ImageConverter::ImageConverter()':
image_converter.cpp:(.text._ZN14ImageConverterC2Ev[_ZN14ImageConverterC5Ev]+0x3f1): undefined reference to `cv::namedWindow(cv::String const&, int)'
CMakeFiles/opencv_cvbridge_tutorial_node.dir/src/image_converter.cpp.o: In function `ImageConverter::~ImageConverter()':
image_converter.cpp:(.text._ZN14ImageConverterD2Ev[_ZN14ImageConverterD5Ev]+0x35): undefined reference to `cv::destroyWindow(cv::String const&)'
CMakeFiles/opencv_cvbridge_tutorial_node.dir/src/image_converter.cpp.o: In function `ImageConverter::imageCb(boost::shared_ptr<sensor_msgs::Image_<std::allocator<void> > const> const&)':
image_converter.cpp:(.text._ZN14ImageConverter7imageCbERKN5boost10shared_ptrIKN11sensor_msgs6Image_ISaIvEEEEE[_ZN14ImageConverter7imageCbERKN5boost10shared_ptrIKN11sensor_msgs6Image_ISaIvEEEEE]+0x1bd): undefined reference to `cv::imshow(cv::String const&, cv::_InputArray const&)'
image_converter.cpp:(.text._ZN14ImageConverter7imageCbERKN5boost10shared_ptrIKN11sensor_msgs6Image_ISaIvEEEEE[_ZN14ImageConverter7imageCbERKN5boost10shared_ptrI


> \#\# Add cmake target dependencies of the executable/library
\#\# as an example, message headers may need to be generated before nodes
KN11sensor_msgs6Image_ISaIvEEEEE]+0x1e2): undefined reference to `cv::waitKey(int)'
collect2: error: ld returned 1 exit status
CMakeFiles/opencv_cvbridge_tutorial_node.dir/build.make:127: recipe for target '/home/dev/catkin_ws/devel_isolated/opencv_cvbridge_tutorial/lib/opencv_cvbridge_tutorial/opencv_cvbridge_tutorial_node' failed